### PR TITLE
Fix Grid Distortion continuity for Angle and Image Height

### DIFF
--- a/diagnostics/grid-distortion-field-modes-repro.mjs
+++ b/diagnostics/grid-distortion-field-modes-repro.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+globalThis.self = new EventTarget();
+
+// Initialize while the runtime is still recognizably Node, then add the small
+// browser globals needed by the shared renderer helpers imported by the client.
+const wasm = await import('../rust-wasm/ts/raytracing/rust-raytracing-wasm.ts');
+const api = await wasm.preloadRustRayTracingWasm();
+assert.ok(api, 'Rust ray-tracing WASM did not initialize');
+const wasmService = await import('../core/wasm-service.ts');
+wasmService.setWASMSystem({ backend: 'rust-wasm', isWASMReady: true, api });
+const { runNativeGridDistortion } = await import('../src/desktop/ipc/client.ts');
+globalThis.window = globalThis;
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+const cases = [
+  {
+    file: 'default-load.json',
+    expectedMode: 'imageheight',
+  },
+  {
+    file: 'US3834556_RETROFUCUS WIDE-ANGLE LENS SYSTEM_1／3.5.json',
+    expectedMode: 'angle',
+  },
+];
+
+const gridSize = 9;
+const summaries = [];
+for (const testCase of cases) {
+  const inputPath = path.join(root, 'Examples', testCase.file);
+  const input = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const result = await runNativeGridDistortion({
+    opticalSystemRows: input.opticalSystem,
+    sourceRows: input.source,
+    objectRows: input.object,
+    gridSize,
+    wavelength: 0.5875618,
+  });
+
+  const pointCount = gridSize * gridSize;
+  assert.equal(result.meta.gridFieldMode, testCase.expectedMode, `${testCase.file}: field mode`);
+  assert.equal(result.realX.length, pointCount, `${testCase.file}: X point count`);
+  assert.equal(result.realY.length, pointCount, `${testCase.file}: Y point count`);
+  assert.equal(result.meta.missingFieldFallbackCount, 0, `${testCase.file}: missing fields`);
+  assert.equal(result.meta.radialWasmChiefRayCount, pointCount, `${testCase.file}: radial chief-ray coverage`);
+  result.realX.forEach((value, index) => assert.ok(Number.isFinite(value), `${testCase.file}: invalid X at ${index}`));
+  result.realY.forEach((value, index) => assert.ok(Number.isFinite(value), `${testCase.file}: invalid Y at ${index}`));
+
+  let maxSymmetryErrorMm = 0;
+  for (let index = 0; index < pointCount; index += 1) {
+    const opposite = pointCount - 1 - index;
+    maxSymmetryErrorMm = Math.max(
+      maxSymmetryErrorMm,
+      Math.abs(result.realX[index] + result.realX[opposite]),
+      Math.abs(result.realY[index] + result.realY[opposite]),
+    );
+  }
+  assert.ok(maxSymmetryErrorMm < 1e-8, `${testCase.file}: broken central symmetry`);
+
+  for (let y = 0; y < gridSize; y += 1) {
+    for (let x = 1; x < gridSize; x += 1) {
+      const previous = y * gridSize + x - 1;
+      const current = y * gridSize + x;
+      assert.ok(result.realX[current] > result.realX[previous], `${testCase.file}: non-monotonic row ${y}`);
+    }
+  }
+  for (let x = 0; x < gridSize; x += 1) {
+    for (let y = 1; y < gridSize; y += 1) {
+      const previous = (y - 1) * gridSize + x;
+      const current = y * gridSize + x;
+      assert.ok(result.realY[current] > result.realY[previous], `${testCase.file}: non-monotonic column ${x}`);
+    }
+  }
+
+  summaries.push({
+    case: testCase.file,
+    mode: result.meta.gridFieldMode,
+    points: pointCount,
+    maxSymmetryErrorMm,
+    radialChiefRays: result.meta.radialWasmChiefRayCount,
+    exactFallbackChiefRays: result.meta.exactWasmChiefRayCount,
+    spotFallbackChiefRays: result.meta.spotFallbackChiefRayCount,
+  });
+}
+
+console.log(JSON.stringify({ ok: true, summaries }, null, 2));

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "diag:zernike-fit-ab": "node --experimental-strip-types diagnostics/zernike-fit-ab-benchmark.mjs",
     "diag:distortion-retrofocus": "node diagnostics/distortion-retrofocus-repro.mjs",
     "diag:distortion-imageheight": "node diagnostics/distortion-imageheight-repro.mjs",
+    "diag:grid-distortion-field-modes": "node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs",
     "wasm:rebuild": "bash ./scripts/build-rust-wasm.sh",
     "wasm:rebuild:threads": "bash -c 'COOPT_WASM_THREADS=1 bash ./scripts/build-rust-wasm.sh'",
     "state:inventory": "node tools/state-inventory.mjs",

--- a/src/desktop/ipc/client.ts
+++ b/src/desktop/ipc/client.ts
@@ -7518,7 +7518,139 @@ export async function runNativeGridDistortion(
 
     const realX = new Array(idealX.length).fill(null) as Array<number | null>;
     const realY = new Array(idealY.length).fill(null) as Array<number | null>;
-    let directChiefRayCount = 0;
+    let radialWasmChiefRayCount = 0;
+    let exactWasmChiefRayCount = 0;
+    let spotFallbackChiefRayCount = 0;
+    let radialWasmChiefRayError = "";
+    let exactWasmChiefRayError = "";
+
+    // Grid distortion needs one deterministic stop-centred chief ray per field.
+    // The spot-diagram generator is designed for pupil sampling and can reject
+    // otherwise valid outer-field chief rays when its sampled bundle is vignetted.
+    // Use the dedicated radial distortion and exact WASM chief-ray tracers first,
+    // reserving spot tracing for uncommon points those solvers cannot reach.
+    try {
+      const { preloadRustRayTracingWasm } = await import(
+        "../../../rust-wasm/ts/raytracing/rust-raytracing-wasm.ts"
+      );
+      const rust = await preloadRustRayTracingWasm();
+      const traceRadialDistortion = (rust as any)?.run_native_distortion_wasm_json;
+
+      // A conventional grid-distortion plot is radial for a centred optical
+      // system. Reuse the same robust distortion solver as the 1-D plot, then
+      // project each traced radial image height back onto its grid azimuth.
+      if (typeof traceRadialDistortion === "function") {
+        try {
+          const radialSamples = idealX.map((x, index) => {
+            const radius = Math.hypot(x, idealY[index]);
+            if (gridFieldMode === "angle") {
+              return (Math.atan(radius / focalLengthForGrid) * 180) / Math.PI;
+            }
+            if (gridFieldMode === "height" && finiteSystem && imageScaleForHeight > 1e-9) {
+              return radius / imageScaleForHeight;
+            }
+            return radius;
+          });
+          // Trace from the axis outwards. The exact chief-ray solver deliberately
+          // reuses the previous field as its next seed, so arbitrary row-major
+          // grid order (corner -> centre -> corner) can lose wide-angle fields.
+          const maxRadialSample = Math.max(0, ...radialSamples);
+          const seedSampleCount = 81;
+          const seedSamples = Array.from({ length: seedSampleCount }, (_, index) => ({
+            sample: maxRadialSample * index / Math.max(1, seedSampleCount - 1),
+            index: null as number | null,
+          }));
+          const radialOrder = radialSamples
+            .map((sample, index) => ({ sample, index: index as number | null }))
+            .concat(seedSamples)
+            .sort((a, b) => a.sample - b.sample);
+          const sortedRadialSamples = radialOrder.map((entry) => entry.sample);
+          const radialRaw = traceRadialDistortion(JSON.stringify({
+            opticalSystemRows,
+            sourceRows,
+            objectRows: inputObjectRows,
+            fieldSamples: sortedRadialSamples,
+            surfaceIndex,
+            heightMode: gridFieldMode !== "angle",
+            wavelength,
+            distortionMetric: "chief-ray",
+          }));
+          const radialResponse = typeof radialRaw === "string" ? JSON.parse(radialRaw) : radialRaw;
+          const radialRealHeights = Array.isArray((radialResponse as any)?.realHeights)
+            ? (radialResponse as any).realHeights
+            : [];
+          for (let sortedIndex = 0; sortedIndex < radialOrder.length; sortedIndex += 1) {
+            const index = radialOrder[sortedIndex].index;
+            if (index === null) continue;
+            const idealRadius = Math.hypot(idealX[index], idealY[index]);
+            const rawRealRadius = radialRealHeights[sortedIndex];
+            if (rawRealRadius === null || rawRealRadius === undefined) continue;
+            const realRadius = Number(rawRealRadius);
+            if (!Number.isFinite(realRadius)) continue;
+            if (idealRadius <= 1e-12) {
+              realX[index] = 0;
+              realY[index] = 0;
+            } else {
+              realX[index] = realRadius * idealX[index] / idealRadius;
+              realY[index] = realRadius * idealY[index] / idealRadius;
+            }
+            radialWasmChiefRayCount += 1;
+          }
+        } catch (error) {
+          radialWasmChiefRayError = String((error as any)?.message || error || "radial WASM distortion failed");
+        }
+      } else {
+        radialWasmChiefRayError = "missing run_native_distortion_wasm_json";
+      }
+
+      const traceInfinite = (rust as any)?.trace_image_height_infinite_candidate_exact_with_rows;
+      const traceFinite = (rust as any)?.trace_image_height_finite_candidate_with_rows;
+      const exactTrace = finiteSystem ? traceFinite : traceInfinite;
+      if (typeof exactTrace !== "function") {
+        throw new Error(finiteSystem
+          ? "missing trace_image_height_finite_candidate_with_rows"
+          : "missing trace_image_height_infinite_candidate_exact_with_rows");
+      }
+
+      const progressStride = Math.max(1, Math.ceil(traceObjectRows.length / 100));
+      for (let index = 0; index < traceObjectRows.length; index += 1) {
+        if (realX[index] !== null && realY[index] !== null) continue;
+        const row = traceObjectRows[index] as any;
+        const inputX = finiteSystem
+          ? Number(row?.xHeight ?? row?.x ?? 0)
+          : Number(row?.xHeightAngle ?? row?.xFieldAngle ?? row?.x ?? 0);
+        const inputY = finiteSystem
+          ? Number(row?.yHeight ?? row?.y ?? 0)
+          : Number(row?.yHeightAngle ?? row?.yFieldAngle ?? row?.y ?? 0);
+        try {
+          const traced = Array.from(exactTrace(
+            opticalSystemRows,
+            surfaceIndex,
+            wavelength,
+            Number.isFinite(inputX) ? inputX : 0,
+            Number.isFinite(inputY) ? inputY : 0,
+          ) as ArrayLike<number>);
+          const status = Number(traced[0]);
+          const xMm = Number(traced[1]);
+          const yMm = Number(traced[2]);
+          if (status === 1 && Number.isFinite(xMm) && Number.isFinite(yMm)) {
+            realX[index] = xMm;
+            realY[index] = yMm;
+            exactWasmChiefRayCount += 1;
+          }
+        } catch {
+          // Leave this point missing so the spot fallback can retry it below.
+        }
+        if ((index + 1) % progressStride === 0 || index + 1 === traceObjectRows.length) {
+          emitProgress(
+            10 + (65 * (index + 1)) / Math.max(1, traceObjectRows.length),
+            `Grid distortion exact chief rays: point ${index + 1}/${traceObjectRows.length}`,
+          );
+        }
+      }
+    } catch (error) {
+      exactWasmChiefRayError = String((error as any)?.message || error || "exact WASM chief ray failed");
+    }
 
     const assignChiefPoint = (row: any) => {
       const match = String(row?.label || "").match(/Field-(\d+)/);
@@ -7535,15 +7667,18 @@ export async function runNativeGridDistortion(
       if (Number.isFinite(xMm) && Number.isFinite(yMm)) {
         realX[index] = xMm;
         realY[index] = yMm;
-        directChiefRayCount += 1;
+        spotFallbackChiefRayCount += 1;
       }
     };
 
-    const totalTracePoints = Math.max(1, traceObjectRows.length);
+    const fallbackObjectRows = traceObjectRows.filter((_, index) => (
+      realX[index] === null || realY[index] === null
+    ));
+    const totalTracePoints = Math.max(1, fallbackObjectRows.length);
     const detailedProgress = payload?.detailProgress === true && onProgress !== null;
-    if (detailedProgress) {
-      for (let i = 0; i < traceObjectRows.length; i += 1) {
-        const row = traceObjectRows[i];
+    if (detailedProgress && fallbackObjectRows.length > 0) {
+      for (let i = 0; i < fallbackObjectRows.length; i += 1) {
+        const row = fallbackObjectRows[i];
         const spotResponse = await runNativeSpotRaytrace({
           opticalSystemRows,
           sourceRows,
@@ -7561,15 +7696,15 @@ export async function runNativeGridDistortion(
           assignChiefPoint(s);
         }
         emitProgress(
-          10 + (80 * (i + 1)) / totalTracePoints,
-          `Grid distortion tracing (Rust/WASM): point ${i + 1}/${totalTracePoints}`,
+          75 + (15 * (i + 1)) / totalTracePoints,
+          `Grid distortion spot fallback: point ${i + 1}/${totalTracePoints}`,
         );
       }
-    } else {
+    } else if (fallbackObjectRows.length > 0) {
       const spotResponse = await runNativeSpotRaytrace({
         opticalSystemRows,
         sourceRows,
-        objectRows: traceObjectRows,
+        objectRows: fallbackObjectRows,
         surfaceIndex,
         rayCount: 11,
         ringCount: 1,
@@ -7585,17 +7720,17 @@ export async function runNativeGridDistortion(
         assignChiefPoint(row);
         processed += 1;
         emitProgress(
-          10 + (80 * processed) / Math.max(1, totalTracePoints),
-          `Grid distortion tracing (Rust/WASM): point ${Math.min(processed, totalTracePoints)}/${totalTracePoints}`,
+          75 + (15 * processed) / Math.max(1, totalTracePoints),
+          `Grid distortion spot fallback: point ${Math.min(processed, totalTracePoints)}/${totalTracePoints}`,
         );
       }
     }
 
     let missingFieldFallbackCount = 0;
     for (let i = 0; i < realX.length; i++) {
-      const rx = Number(realX[i]);
-      const ry = Number(realY[i]);
-      if (!Number.isFinite(rx) || !Number.isFinite(ry)) {
+      const rx = realX[i];
+      const ry = realY[i];
+      if (rx === null || ry === null || !Number.isFinite(rx) || !Number.isFinite(ry)) {
         realX[i] = null;
         realY[i] = null;
         missingFieldFallbackCount += 1;
@@ -7623,7 +7758,12 @@ export async function runNativeGridDistortion(
         maxImageX: scaledMaxImageX,
         maxImageY: scaledMaxImageY,
         surfaceIndex,
-        directChiefRayCount,
+        directChiefRayCount: radialWasmChiefRayCount + exactWasmChiefRayCount + spotFallbackChiefRayCount,
+        radialWasmChiefRayCount,
+        exactWasmChiefRayCount,
+        spotFallbackChiefRayCount,
+        radialWasmChiefRayError,
+        exactWasmChiefRayError,
         missingFieldFallbackCount,
         detailedProgressUsed: detailedProgress,
       },


### PR DESCRIPTION
## Summary
- compute centred-system Grid Distortion through the robust radial chief-ray WASM path
- trace fields from the optical axis outward with dense seeds so wide-angle chief-ray aiming remains continuous
- use exact chief rays and spot tracing only as fallbacks, and correctly count null/missing fields
- add an Angle/Image Height Grid Distortion regression using the reported example files

## Validation
- `npm run diag:grid-distortion-field-modes`
- `npm run diag:distortion-imageheight`
- `npm run diag:distortion-retrofocus`
- production Vite build