### PR TITLE
Stop local Grid Distortion lines from connecting to center

### DIFF
--- a/diagnostics/grid-distortion-null-plot-repro.mjs
+++ b/diagnostics/grid-distortion-null-plot-repro.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+
+globalThis.window = globalThis;
+globalThis.addEventListener = () => {};
+globalThis.removeEventListener = () => {};
+globalThis.document = { getElementById: () => null };
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+const calls = [];
+const target = {
+  ownerDocument: {
+    defaultView: {
+      Plotly: { newPlot: (...args) => calls.push(args) },
+    },
+  },
+};
+
+const { plotGridDistortion } = await import('../evaluation/aberrations/distortion-plot.ts');
+const axis = [-1, 0, 1];
+const idealX = [];
+const idealY = [];
+for (const y of axis) {
+  for (const x of axis) {
+    idealX.push(x);
+    idealY.push(y);
+  }
+}
+const realX = idealX.map((x) => x * 0.9);
+const realY = idealY.map((y) => y * 0.9);
+realX[0] = null;
+realY[0] = null;
+
+await plotGridDistortion({
+  idealGrid: { x: idealX, y: idealY },
+  realGrid: { x: realX, y: realY },
+  gridSize: 3,
+  maxFieldAngle: 20,
+  meta: { wavelength: 0.5875618, requestedGridSize: 2 },
+}, target, null, { enlargementFactor: 1 });
+
+assert.equal(calls.length, 1, 'Plotly should render exactly once');
+const traces = calls[0][1];
+const distortedTraces = traces.filter((trace) => trace.line?.color === '#ff0000');
+assert.equal(distortedTraces.length, 6, 'three distorted rows plus three distorted columns');
+assert.equal(distortedTraces[0].x[0], null, 'missing X must remain a line break');
+assert.equal(distortedTraces[0].y[0], null, 'missing Y must remain a line break');
+assert.equal(distortedTraces[3].x[0], null, 'column mesh must preserve missing X');
+assert.equal(distortedTraces[3].y[0], null, 'column mesh must preserve missing Y');
+assert.equal(distortedTraces[0].connectgaps, false);
+
+console.log(JSON.stringify({
+  ok: true,
+  missingPoint: { x: distortedTraces[0].x[0], y: distortedTraces[0].y[0] },
+  connectGaps: distortedTraces[0].connectgaps,
+  distortedMeshTraceCount: distortedTraces.length,
+}, null, 2));

--- a/evaluation/aberrations/distortion-plot.ts
+++ b/evaluation/aberrations/distortion-plot.ts
@@ -407,14 +407,20 @@ export async function plotGridDistortion(data, targetDivId = 'distortion-grid', 
   const horizontalOffset = estimateGridHorizontalOffset(idealGrid, realGrid);
   const offsetRealGrid = {
     x: realGrid.x.map((value) => {
+      if (value === null || value === undefined) return null;
       const x = Number(value);
       if (!Number.isFinite(x)) return null;
       return Number.isFinite(Number(horizontalOffset)) ? x + Number(horizontalOffset) : x;
     }),
-    y: realGrid.y,
+    y: realGrid.y.map((value) => {
+      if (value === null || value === undefined) return null;
+      const y = Number(value);
+      return Number.isFinite(y) ? y : null;
+    }),
   };
   const scaledRealGrid = {
     x: offsetRealGrid.x.map((value, index) => {
+      if (value === null || value === undefined) return null;
       const realX = Number(value);
       const idealX = Number(idealGrid.x[index]);
       if (!Number.isFinite(realX) || !Number.isFinite(idealX)) return null;
@@ -422,6 +428,7 @@ export async function plotGridDistortion(data, targetDivId = 'distortion-grid', 
       return idealX - distortionX;
     }),
     y: offsetRealGrid.y.map((value, index) => {
+      if (value === null || value === undefined) return null;
       const realY = Number(value);
       const idealY = Number(idealGrid.y[index]);
       if (!Number.isFinite(realY) || !Number.isFinite(idealY)) return null;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "diag:distortion-retrofocus": "node diagnostics/distortion-retrofocus-repro.mjs",
     "diag:distortion-imageheight": "node diagnostics/distortion-imageheight-repro.mjs",
     "diag:grid-distortion-field-modes": "node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs",
+    "diag:grid-distortion-null-plot": "node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs",
     "wasm:rebuild": "bash ./scripts/build-rust-wasm.sh",
     "wasm:rebuild:threads": "bash -c 'COOPT_WASM_THREADS=1 bash ./scripts/build-rust-wasm.sh'",
     "state:inventory": "node tools/state-inventory.mjs",


### PR DESCRIPTION
## Summary
- preserve missing Grid Distortion coordinates as `null` during display scaling
- let Plotly break the affected row and column with `connectgaps: false` instead of converting missing coordinates to `(0, 0)`
- keep the fully valid web Grid Distortion mesh unchanged
- add a plotting regression for a missing local/native field point

## Root cause
JavaScript `Number(null)` evaluates to zero. Missing native ray intersections were therefore rendered at the image center, producing straight lines from valid peripheral points to `(0, 0)`.

## Validation
- `npm run diag:grid-distortion-null-plot`
- `npm run diag:grid-distortion-field-modes`
- production Vite build