### PR TITLE
Fix Tele Grid Distortion fallback

### DIFF
--- a/diagnostics/grid-distortion-tele-repro.mjs
+++ b/diagnostics/grid-distortion-tele-repro.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+globalThis.self = new EventTarget();
+
+const wasm = await import('../rust-wasm/ts/raytracing/rust-raytracing-wasm.ts');
+const api = await wasm.preloadRustRayTracingWasm();
+assert.ok(api, 'Rust ray-tracing WASM did not initialize');
+const wasmService = await import('../core/wasm-service.ts');
+wasmService.setWASMSystem({ backend: 'rust-wasm', isWASMReady: true, api });
+const { runNativeGridDistortion } = await import('../src/desktop/ipc/client.ts');
+globalThis.window = globalThis;
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+const input = JSON.parse(fs.readFileSync(new URL('../Examples/default-load.json', import.meta.url), 'utf8'));
+const tele = input.configurations.configurations.find((configuration) => configuration.name === 'Tele');
+assert.ok(tele, 'Tele configuration is missing');
+
+const gridSize = 16;
+const result = await runNativeGridDistortion({
+  opticalSystemRows: tele.opticalSystem,
+  sourceRows: input.source,
+  objectRows: tele.object,
+  gridSize,
+  wavelength: 0.5875618,
+});
+
+const pointCount = gridSize * gridSize;
+assert.equal(result.meta.gridFieldMode, 'imageheight');
+assert.equal(result.realX.length, pointCount);
+assert.equal(result.realY.length, pointCount);
+assert.ok(Math.abs(result.meta.objectMaxHeight - 21.6) < 1e-12, 'Tele image height was not read from the object table');
+assert.ok(result.meta.directChiefRayCount >= pointCount - 4, 'more than the four extreme corners were lost');
+assert.ok(result.meta.missingFieldFallbackCount <= 4, 'unexpected missing Grid Distortion fields');
+assert.ok(result.meta.spotFallbackChiefRayError, 'the rejected Spot fallback should be diagnosed');
+
+const missingIndices = [];
+for (let index = 0; index < pointCount; index += 1) {
+  const x = result.realX[index];
+  const y = result.realY[index];
+  if (x === null || y === null) {
+    missingIndices.push(index);
+  } else {
+    assert.ok(Number.isFinite(x), `invalid X at ${index}`);
+    assert.ok(Number.isFinite(y), `invalid Y at ${index}`);
+  }
+}
+assert.deepEqual(missingIndices, [0, gridSize - 1, pointCount - gridSize, pointCount - 1]);
+
+console.log(JSON.stringify({
+  ok: true,
+  backend: result.backend,
+  points: pointCount,
+  missingIndices,
+  meta: result.meta,
+}, null, 2));

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "diag:distortion-imageheight": "node diagnostics/distortion-imageheight-repro.mjs",
     "diag:grid-distortion-field-modes": "node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs",
     "diag:grid-distortion-null-plot": "node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs",
+    "diag:grid-distortion-tele": "node --import tsx diagnostics/grid-distortion-tele-repro.mjs",
     "wasm:rebuild": "bash ./scripts/build-rust-wasm.sh",
     "wasm:rebuild:threads": "bash -c 'COOPT_WASM_THREADS=1 bash ./scripts/build-rust-wasm.sh'",
     "state:inventory": "node tools/state-inventory.mjs",

--- a/src/desktop/ipc/client.ts
+++ b/src/desktop/ipc/client.ts
@@ -1444,9 +1444,10 @@ function readGridFieldVectorNativeLike(row: any, mode: "angle" | "height" | "ima
 
   if (mode === "imageheight") {
     return {
-      // Do not mix angle columns into image-height extents.
-      x: pick(row?.__cooptImageHeightTarget?.x, row?.xHeight, row?.x, row?.["object x"]),
-      y: pick(row?.__cooptImageHeightTarget?.y, row?.yHeight, row?.y, row?.["object y"]),
+      // Object-table data keeps the selected field value in the historical
+      // xHeightAngle/yHeightAngle columns; position defines its actual unit.
+      x: pick(row?.__cooptImageHeightTarget?.x, row?.xHeight, row?.xHeightAngle, row?.x, row?.["object x"]),
+      y: pick(row?.__cooptImageHeightTarget?.y, row?.yHeight, row?.yHeightAngle, row?.y, row?.["object y"]),
     };
   }
 
@@ -7523,6 +7524,7 @@ export async function runNativeGridDistortion(
     let spotFallbackChiefRayCount = 0;
     let radialWasmChiefRayError = "";
     let exactWasmChiefRayError = "";
+    let spotFallbackChiefRayError = "";
 
     // Grid distortion needs one deterministic stop-centred chief ray per field.
     // The spot-diagram generator is designed for pupil sampling and can reject
@@ -7679,10 +7681,41 @@ export async function runNativeGridDistortion(
     if (detailedProgress && fallbackObjectRows.length > 0) {
       for (let i = 0; i < fallbackObjectRows.length; i += 1) {
         const row = fallbackObjectRows[i];
+        try {
+          const spotResponse = await runNativeSpotRaytrace({
+            opticalSystemRows,
+            sourceRows,
+            objectRows: [row],
+            surfaceIndex,
+            rayCount: 11,
+            ringCount: 1,
+            pattern: "cross",
+            wavelengthMode: "primary",
+            forceRustWasm: true,
+            strictChiefOnly: true,
+          });
+          const series = Array.isArray(spotResponse?.series) ? spotResponse.series : [];
+          for (const s of series as any[]) {
+            assignChiefPoint(s);
+          }
+        } catch (error) {
+          if (!spotFallbackChiefRayError) {
+            spotFallbackChiefRayError = String(
+              (error as any)?.message || error || "spot fallback chief ray failed",
+            );
+          }
+        }
+        emitProgress(
+          75 + (15 * (i + 1)) / totalTracePoints,
+          `Grid distortion spot fallback: point ${i + 1}/${totalTracePoints}`,
+        );
+      }
+    } else if (fallbackObjectRows.length > 0) {
+      try {
         const spotResponse = await runNativeSpotRaytrace({
           opticalSystemRows,
           sourceRows,
-          objectRows: [row],
+          objectRows: fallbackObjectRows,
           surfaceIndex,
           rayCount: 11,
           ringCount: 1,
@@ -7691,37 +7724,20 @@ export async function runNativeGridDistortion(
           forceRustWasm: true,
           strictChiefOnly: true,
         });
-        const series = Array.isArray(spotResponse?.series) ? spotResponse.series : [];
-        for (const s of series as any[]) {
-          assignChiefPoint(s);
-        }
-        emitProgress(
-          75 + (15 * (i + 1)) / totalTracePoints,
-          `Grid distortion spot fallback: point ${i + 1}/${totalTracePoints}`,
-        );
-      }
-    } else if (fallbackObjectRows.length > 0) {
-      const spotResponse = await runNativeSpotRaytrace({
-        opticalSystemRows,
-        sourceRows,
-        objectRows: fallbackObjectRows,
-        surfaceIndex,
-        rayCount: 11,
-        ringCount: 1,
-        pattern: "cross",
-        wavelengthMode: "primary",
-        forceRustWasm: true,
-        strictChiefOnly: true,
-      });
 
-      const series = Array.isArray(spotResponse?.series) ? spotResponse.series : [];
-      let processed = 0;
-      for (const row of series as any[]) {
-        assignChiefPoint(row);
-        processed += 1;
-        emitProgress(
-          75 + (15 * processed) / Math.max(1, totalTracePoints),
-          `Grid distortion spot fallback: point ${Math.min(processed, totalTracePoints)}/${totalTracePoints}`,
+        const series = Array.isArray(spotResponse?.series) ? spotResponse.series : [];
+        let processed = 0;
+        for (const row of series as any[]) {
+          assignChiefPoint(row);
+          processed += 1;
+          emitProgress(
+            75 + (15 * processed) / Math.max(1, totalTracePoints),
+            `Grid distortion spot fallback: point ${Math.min(processed, totalTracePoints)}/${totalTracePoints}`,
+          );
+        }
+      } catch (error) {
+        spotFallbackChiefRayError = String(
+          (error as any)?.message || error || "spot fallback chief ray failed",
         );
       }
     }
@@ -7764,6 +7780,7 @@ export async function runNativeGridDistortion(
         spotFallbackChiefRayCount,
         radialWasmChiefRayError,
         exactWasmChiefRayError,
+        spotFallbackChiefRayError,
         missingFieldFallbackCount,
         detailedProgressUsed: detailedProgress,
       },


### PR DESCRIPTION
## What changed

- Read legacy `xHeightAngle/yHeightAngle` object-table values as image heights when `position` is `ImageHeight`.
- Contain Spot fallback failures so physically unreachable Grid Distortion points remain null instead of aborting the whole analysis.
- Report the Spot fallback error in Grid Distortion metadata.
- Add a 16×16 Tele regression reproducing Surf 23 and its four unreachable corner fields.

## Root cause

The Tele image height of 21.6 mm is stored in the historical object-table value columns, but the web Grid Distortion extent reader ignored those columns and substituted 20 mm. Once the true 21.6 mm extent is used, the four extreme diagonal corner chief rays do not reach Surf 23. The final Spot fallback then threw an all-rays-failed exception that escaped from the Grid Distortion request.

## Impact

The web analysis now returns and plots all 252 reachable points. The four physically unreachable corners remain explicit null gaps, so they are not fabricated or connected toward the plot center.

## Validation

- `node --import tsx diagnostics/grid-distortion-tele-repro.mjs`
- `node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs`
- `node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs`
- Vite production build