### PR TITLE
Fix spherical aberration discontinuities

### DIFF
--- a/diagnostics/spherical-aberration-continuity-repro.mjs
+++ b/diagnostics/spherical-aberration-continuity-repro.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+globalThis.self = new EventTarget();
+const wasm = await import('../rust-wasm/ts/raytracing/rust-raytracing-wasm.ts');
+const api = await wasm.preloadRustRayTracingWasm();
+assert.ok(api, 'Rust ray-tracing WASM did not initialize');
+const wasmService = await import('../core/wasm-service.ts');
+wasmService.setWASMSystem({ backend: 'rust-wasm', isWASMReady: true, api });
+const { runNativeSphericalAberration } = await import('../src/desktop/ipc/client.ts');
+globalThis.window = globalThis;
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+globalThis.document = { getElementById: () => null, querySelector: () => null };
+
+const input = JSON.parse(fs.readFileSync(new URL('../Examples/default-load.json', import.meta.url), 'utf8'));
+const configurations = input.configurations.configurations;
+const summaries = [];
+const originalLog = console.log;
+const originalWarn = console.warn;
+console.log = () => {};
+console.warn = () => {};
+
+for (const configuration of configurations) {
+  const result = await runNativeSphericalAberration({
+    opticalSystemRows: configuration.opticalSystem,
+    sourceRows: input.source,
+    objectRows: configuration.object,
+    rayCount: 51,
+    wavelengthMode: 'all',
+    referenceFocusMode: 'current-paraxial',
+  });
+
+  for (const axis of ['meridionalData', 'sagittalData']) {
+    for (const series of result[axis] || []) {
+      const points = [...(series.points || [])]
+        .filter((point) => Number.isFinite(point.pupilCoordinate) && Number.isFinite(point.longitudinalAberration))
+        .sort((a, b) => a.pupilCoordinate - b.pupilCoordinate);
+      const jumps = [];
+      for (let index = 1; index < points.length; index += 1) {
+        jumps.push({
+          index,
+          dp: points[index].pupilCoordinate - points[index - 1].pupilCoordinate,
+          dx: points[index].longitudinalAberration - points[index - 1].longitudinalAberration,
+        });
+      }
+      jumps.sort((a, b) => Math.abs(b.dx) - Math.abs(a.dx));
+      const largest = jumps[0] || { index: 0, dp: 0, dx: 0 };
+      const start = Math.max(0, largest.index - 2);
+      const end = Math.min(points.length, largest.index + 3);
+      summaries.push({
+        configuration: configuration.name,
+        axis,
+        wavelength: series.wavelength,
+        pointCount: points.length,
+        pupilMin: points[0]?.pupilCoordinate ?? null,
+        pupilMax: points.at(-1)?.pupilCoordinate ?? null,
+        largestJump: largest,
+        neighborhood: points.slice(start, end).map((point) => ({
+          pupil: point.pupilCoordinate,
+          aberration: point.longitudinalAberration,
+        })),
+      });
+      assert.ok(
+        Math.abs(largest.dx) < 0.15,
+        `${configuration.name} ${axis} ${series.wavelength}: discontinuous jump ${largest.dx} mm`,
+      );
+    }
+  }
+}
+
+console.log = originalLog;
+console.warn = originalWarn;
+originalLog(JSON.stringify({ ok: true, summaries }, null, 2));

--- a/evaluation/aberrations/longitudinal-aberration.ts
+++ b/evaluation/aberrations/longitudinal-aberration.ts
@@ -321,17 +321,16 @@ function resamplePointsToRequestedPupilCoordinates(points, requestedSamples) {
     const leftPair = findDistinctNeighborPair(sorted, true);
     const rightPair = findDistinctNeighborPair(sorted, false);
 
-    // 外挿限界: データ範囲の20%まで、またはデータカバレッジが50%未満の場合は外挿しない
+    // Trace failures mark the physical/traceable pupil boundary. Never invent
+    // samples beyond the measured range; doing so connects unrelated branches.
     const dataMin = sorted[0].pupilCoordinate;
     const dataMax = sorted[sorted.length - 1].pupilCoordinate;
-    const dataRange = dataMax - dataMin;
     const coverageRatio = dataMax; // 0〜1の範囲でのカバレッジ
-    const extrapolationMargin = coverageRatio < 0.5 ? 0 : dataRange * 0.2;
-    const extrapolationMax = dataMax + extrapolationMargin;
-    const extrapolationMin = Math.max(0, dataMin - extrapolationMargin);
+    const extrapolationMax = dataMax;
+    const extrapolationMin = dataMin;
     
     if (coverageRatio < 0.8) {
-        console.warn(`⚠️ [SA resample] データカバレッジ不足: ${(coverageRatio * 100).toFixed(1)}% (最大瞳座標=${dataMax.toFixed(4)}, ${sorted.length}点). 外挿限界=${extrapolationMax.toFixed(4)}`);
+        console.warn(`⚠️ [SA resample] データカバレッジ不足: ${(coverageRatio * 100).toFixed(1)}% (最大瞳座標=${dataMax.toFixed(4)}, ${sorted.length}点). 未到達領域は描画しません`);
     }
 
     const out = [];
@@ -1557,12 +1556,13 @@ export function calculateLongitudinalAberration(
             sagittal: aimedSagittalRays ? aimedSagittalRays.length : null
         });
 
-        // メリジオナル光線の縦収差を計算（垂直クロス光線）
-        // Aimed rays と cross-beam rays を統合してフルアパーチャのカバレッジを確保する。
-        // stop-solve が高瞳座標で失敗した場合でも、cross-beam rays がデータを補完する。
+        // メリジオナル光線の縦収差を計算（垂直クロス光線）。
+        // Aimed rays and cross-beam rays use different pupil parameterizations;
+        // mixing them can splice different focus branches at the same coordinate.
+        // Use cross-beam rays only when aiming produced no usable series at all.
         const crossBeamMeridional = successfulRays.filter(r => r.originalRay && r.originalRay.type === 'vertical_cross');
         const meridionalRays = (aimedMeridionalRays && aimedMeridionalRays.length > 0)
-            ? [...aimedMeridionalRays, ...crossBeamMeridional]
+            ? aimedMeridionalRays
             : crossBeamMeridional;
         const meridionalUsingFallback = !(aimedMeridionalRays && aimedMeridionalRays.length > 0);
         stageCount.meridional.fallbackRayCount = meridionalUsingFallback ? meridionalRays.length : 0;
@@ -1731,11 +1731,10 @@ export function calculateLongitudinalAberration(
                 : null
         });
         
-        // サジタル光線の縦収差を計算
-        // Aimed rays と cross-beam rays を統合してフルアパーチャのカバレッジを確保する。
+        // サジタル光線も同じ規則で、異なる瞳パラメータの混在を避ける。
         const crossBeamSagittal = successfulRays.filter(r => r.originalRay && r.originalRay.type === 'horizontal_cross');
         const sagittalRays = (aimedSagittalRays && aimedSagittalRays.length > 0)
-            ? [...aimedSagittalRays, ...crossBeamSagittal]
+            ? aimedSagittalRays
             : crossBeamSagittal;
         const sagittalUsingFallback = !(aimedSagittalRays && aimedSagittalRays.length > 0);
         stageCount.sagittal.fallbackRayCount = sagittalUsingFallback ? sagittalRays.length : 0;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "diag:grid-distortion-field-modes": "node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs",
     "diag:grid-distortion-null-plot": "node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs",
     "diag:grid-distortion-tele": "node --import tsx diagnostics/grid-distortion-tele-repro.mjs",
+    "diag:spherical-aberration-continuity": "node --import tsx diagnostics/spherical-aberration-continuity-repro.mjs",
     "wasm:rebuild": "bash ./scripts/build-rust-wasm.sh",
     "wasm:rebuild:threads": "bash -c 'COOPT_WASM_THREADS=1 bash ./scripts/build-rust-wasm.sh'",
     "state:inventory": "node tools/state-inventory.mjs",


### PR DESCRIPTION
## What changed

- Keep stop-aimed spherical-aberration rays separate from cross-beam fallback rays.
- Use cross-beam rays only when no aimed series can be traced.
- Stop resampling at the measured pupil boundary instead of extrapolating beyond failed rays.
- Add Wide/Middle/Tele continuity regression coverage.

## Root cause

The calculator merged two ray families with different pupil parameterizations into one curve. In Wide, aimed rays ended near normalized pupil 0.58, then unrelated cross-beam rays were assigned to the next requested samples. Plotly correctly connected those values, exposing an artificial 0.35–0.51 mm jump. The resampler also extrapolated into the untraced pupil region.

## Impact

Spherical Aberration now plots only a single consistent focus branch. Physically unreachable outer-pupil regions remain unplotted instead of being fabricated.

## Validation

- `node --import tsx diagnostics/spherical-aberration-continuity-repro.mjs`
- `node --import tsx diagnostics/grid-distortion-field-modes-repro.mjs`
- `node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs`
- Vite production build