### PR TITLE
Fix Wide lateral chromatic continuity

### DIFF
--- a/analysis/optical-analysis.ts
+++ b/analysis/optical-analysis.ts
@@ -3428,10 +3428,10 @@ export async function showMagnificationChromaticAberrationDiagram(options: any =
         let smoothingAdjacentPoints = Number.isFinite(optSmoothingAdjacentPoints)
             ? Math.round(optSmoothingAdjacentPoints)
             : Number(smoothingAdjacentPointsInput?.value);
-        if (!Number.isFinite(pointCount) || pointCount < 2) pointCount = 11;
+        if (!Number.isFinite(pointCount) || pointCount < 2) pointCount = 41;
         if (!Number.isFinite(rayCount) || rayCount < 1) rayCount = 101;
         if (!Number.isFinite(ringCount) || ringCount < 1) ringCount = 30;
-        if (!Number.isFinite(smoothingAdjacentPoints) || smoothingAdjacentPoints < 0) smoothingAdjacentPoints = 1;
+        if (!Number.isFinite(smoothingAdjacentPoints) || smoothingAdjacentPoints < 0) smoothingAdjacentPoints = 0;
         if (smoothingAdjacentPoints > 50) smoothingAdjacentPoints = 50;
 
         const fieldValues: number[] = [];

--- a/diagnostics/lateral-chromatic-wide-repro.mjs
+++ b/diagnostics/lateral-chromatic-wide-repro.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+globalThis.self = new EventTarget();
+const wasm = await import('../rust-wasm/ts/raytracing/rust-raytracing-wasm.ts');
+const api = await wasm.preloadRustRayTracingWasm();
+assert.ok(api, 'Rust ray-tracing WASM did not initialize');
+const wasmService = await import('../core/wasm-service.ts');
+wasmService.setWASMSystem({ backend: 'rust-wasm', isWASMReady: true, api });
+const { runNativeMagnificationChromaticAberration } = await import('../src/desktop/ipc/client.ts');
+globalThis.window = globalThis;
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+globalThis.document = { getElementById: () => null, querySelector: () => null };
+
+const input = JSON.parse(fs.readFileSync(new URL('../Examples/default-load.json', import.meta.url), 'utf8'));
+const configuration = input.configurations.configurations.find((entry) => entry.name === 'Wide');
+assert.ok(configuration, 'Wide configuration was not found');
+
+const pointCount = 41;
+const maxImageHeight = Math.max(...configuration.object.map((row) => Math.abs(Number(row.yHeightAngle) || 0)));
+const fieldSamples = Array.from({ length: pointCount }, (_, index) => maxImageHeight * index / (pointCount - 1));
+const wavelengths = input.source.map((row) => Number(row.wavelength)).filter(Number.isFinite);
+const referenceWavelength = Number(input.source.find((row) => String(row.primary || '').includes('Primary'))?.wavelength);
+
+const originalLog = console.log;
+const originalWarn = console.warn;
+console.log = () => {};
+console.warn = () => {};
+const result = await runNativeMagnificationChromaticAberration({
+  opticalSystemRows: configuration.opticalSystem,
+  sourceRows: input.source,
+  fieldSamples,
+  wavelengths,
+  referenceWavelength,
+  heightMode: true,
+  imageHeightMode: true,
+  rayCount: 101,
+  ringCount: 30,
+  chiefRayDefinition: 'stop-center',
+});
+console.log = originalLog;
+console.warn = originalWarn;
+
+assert.ok(result, 'Wide LCA calculation failed');
+assert.equal(result.fieldValues.length, pointCount);
+
+const summaries = [];
+for (const series of result.dataByWavelength) {
+  assert.equal(series.displacements.length, pointCount);
+  assert.ok(series.displacements.every(Number.isFinite), `non-finite LCA value at ${series.wavelength}`);
+
+  const steps = series.displacements.slice(1).map((value, index) => value - series.displacements[index]);
+  const maxAdjacentJump = Math.max(...steps.map(Math.abs));
+  assert.ok(maxAdjacentJump < 0.001, `${series.wavelength}: discontinuous LCA jump ${maxAdjacentJump} mm`);
+
+  if (Math.abs(Number(series.wavelength) - referenceWavelength) < 1e-9) {
+    const maxReferenceHeightError = Math.max(...series.imageHeights.map((height, index) => Math.abs(height - fieldSamples[index])));
+    assert.ok(maxReferenceHeightError < 1e-4, `ImageHeight inverse solve error ${maxReferenceHeightError} mm`);
+  } else if (Number(series.wavelength) < referenceWavelength) {
+    assert.ok(steps.every((step) => step <= 1e-8), `${series.wavelength}: blue LCA is not monotonic`);
+  } else {
+    assert.ok(steps.every((step) => step >= -1e-8), `${series.wavelength}: red LCA is not monotonic`);
+  }
+
+  summaries.push({
+    wavelength: series.wavelength,
+    pointCount: series.displacements.length,
+    minMm: Math.min(...series.displacements),
+    maxMm: Math.max(...series.displacements),
+    maxAdjacentJumpMm: maxAdjacentJump,
+  });
+}
+
+originalLog(JSON.stringify({ ok: true, configuration: 'Wide', maxImageHeight, summaries }, null, 2));

--- a/evaluation/aberrations/magnification-chromatic-aberration-plot.ts
+++ b/evaluation/aberrations/magnification-chromatic-aberration-plot.ts
@@ -47,8 +47,9 @@ function smoothByAdjacentWindow(x: Array<number | null>, adjacentCount: number):
 
     const out = x.slice();
     for (let i = 1; i < n - 1; i++) {
-        let sum = 0;
-        let count = 0;
+        const center = x[i];
+        let sum = (typeof center === 'number' && Number.isFinite(center)) ? center : 0;
+        let count = (typeof center === 'number' && Number.isFinite(center)) ? 1 : 0;
         let leftCount = 0;
         let rightCount = 0;
 
@@ -74,7 +75,7 @@ function smoothByAdjacentWindow(x: Array<number | null>, adjacentCount: number):
             }
         }
 
-        if (leftCount > 0 && rightCount > 0 && count > 0) {
+        if (leftCount > 0 && rightCount > 0 && count > 1) {
             out[i] = sum / count;
         }
     }

--- a/evaluation/aberrations/magnification-chromatic-aberration.ts
+++ b/evaluation/aberrations/magnification-chromatic-aberration.ts
@@ -505,33 +505,67 @@ export async function calculateMagnificationChromaticAberrationData(
         await preloadRustRayTracingWasm();
         const {
             generateRayStartPointsForObject,
+            convertImageHeightToEffectiveObject,
+            traceChiefRayForAngleDetails,
         } = await import('../../optical/ray-renderer.ts');
-        const { traceRayEvalBatchSummary } = await import('../../raytracing/core/ray-tracing.ts');
+        const { traceRayEvalBatchSummary, calculateSurfaceOrigins } = await import('../../raytracing/core/ray-tracing.ts');
         const { calculateParaxialData } = await import('../../raytracing/core/ray-paraxial.ts');
+        const { findStopSurface } = await import('../../optical/system-renderer.ts');
 
-        // For LCA in ImageHeight mode, avoid per-point nonlinear back-solve.
-        // Convert target image heights to a stable paraxial angle sweep once.
+        const imageHeightSolveSurfaceOrigins = imageHeightMode ? calculateSurfaceOrigins(opticalSystemRows) : null;
+        const imageHeightSolveStopInfo = imageHeightMode
+            ? findStopSurface(opticalSystemRows, imageHeightSolveSurfaceOrigins)
+            : null;
+        const imageHeightSolveStopCenter = (() => {
+            const src = imageHeightSolveStopInfo?.origin?.origin
+                ?? imageHeightSolveStopInfo?.origin
+                ?? imageHeightSolveStopInfo?.center
+                ?? imageHeightSolveStopInfo?.position;
+            const x = Number(src?.x);
+            const y = Number(src?.y);
+            const z = Number(src?.z);
+            return [x, y, z].every(Number.isFinite) ? { x, y, z } : null;
+        })();
+        const imageHeightSolveScopeKey = imageHeightMode
+            ? `${JSON.stringify(opticalSystemRows)}||${referenceWavelength}||${imageHeightConjugateType || 'infinite'}||rust-only`
+            : null;
+
+        // ImageHeight is the requested reference-wavelength chief-ray image height,
+        // not merely EFL*tan(field angle). Solve that inverse mapping exactly once at
+        // the reference wavelength, then keep the solved object field fixed for every
+        // wavelength. The previous paraxial-only conversion switched chief-ray origin
+        // fallbacks in Wide near 11 mm and produced artificial straight/kinked LCA curves.
         const tracedObjectRows = (() => {
             if (!imageHeightMode) return objectRowsNativeLike;
             const paraxial = calculateParaxialData(opticalSystemRows, referenceWavelength);
-            const focalLength = Number(paraxial?.focalLength);
-            const effectiveFocalLength = (Number.isFinite(focalLength) && Math.abs(focalLength) > 1e-12)
-                ? Math.abs(focalLength)
-                : 1;
             return sortedFieldValues.map((sample, index) => {
                 const yMm = Number(sample);
-                const thetaDeg = Math.atan2(Number.isFinite(yMm) ? yMm : 0, effectiveFocalLength) * (180 / Math.PI);
-                return {
+                const rawImageHeightObject = {
                     id: `Field-${index}`,
                     name: `Field-${index}`,
-                    position: 'Angle',
+                    position: 'ImageHeight',
                     xHeightAngle: 0,
-                    yHeightAngle: thetaDeg,
+                    yHeightAngle: Number.isFinite(yMm) ? yMm : 0,
                     x: 0,
-                    y: thetaDeg,
+                    y: Number.isFinite(yMm) ? yMm : 0,
                     __cooptImageHeightTarget: { x: 0, y: Number.isFinite(yMm) ? yMm : 0 },
-                    __cooptLcaImageHeightParaxialAngleDeg: thetaDeg,
                 };
+                return convertImageHeightToEffectiveObject(
+                    rawImageHeightObject,
+                    opticalSystemRows,
+                    referenceWavelength,
+                    imageHeightConjugateType === 'finite' ? 'finite' : 'infinite',
+                    {
+                        skipTsValidation: true,
+                        validationTraceBackend: 'rust',
+                        precomputedParaxial: paraxial,
+                        precomputedSurfaceOrigins: imageHeightSolveSurfaceOrigins,
+                        precomputedImageSurfaceIndex: imageSurfaceIndex,
+                        precomputedStopInfo: imageHeightSolveStopInfo,
+                        precomputedStopCenter3d: imageHeightSolveStopCenter,
+                        precomputedSolveScopeKey: imageHeightSolveScopeKey,
+                    },
+                );
             });
         })();
 
@@ -556,6 +590,30 @@ export async function calculateMagnificationChromaticAberrationData(
         } as any;
 
         const traceChiefImageHeightMm = (obj: any, wl: number): number | null => {
+            const solvedFieldX = Number(obj?.__cooptImageHeightSolve?.solved?.x);
+            const solvedFieldY = Number(obj?.__cooptImageHeightSolve?.solved?.y);
+            if (imageHeightMode
+                && imageHeightConjugateType !== 'finite'
+                && Number.isFinite(solvedFieldX)
+                && Number.isFinite(solvedFieldY)) {
+                const details = traceChiefRayForAngleDetails(
+                    opticalSystemRows,
+                    solvedFieldX,
+                    solvedFieldY,
+                    imageSurfaceIndex,
+                    imageHeightSolveSurfaceOrigins?.[imageSurfaceIndex] || null,
+                    wl,
+                    {
+                        surfaceOrigins: imageHeightSolveSurfaceOrigins,
+                        stopInfo: imageHeightSolveStopInfo,
+                        stopCenter3d: imageHeightSolveStopCenter,
+                    },
+                    'rust',
+                );
+                const localHitY = Number(details?.localHit?.y);
+                if (Number.isFinite(localHitY)) return localHitY * mirrorSign;
+            }
+
             const starts = generateRayStartPointsForObject(
                 obj,
                 opticalSystemRows,

--- a/optical/ray-renderer.ts
+++ b/optical/ray-renderer.ts
@@ -1471,7 +1471,7 @@ function isParaxialOnlyImageHeightModel(opticalSystemRows) {
     return sawParaxialSurface;
 }
 
-function traceChiefRayForAngleDetails(opticalSystemRows, angleXDeg, angleYDeg, imageSurfaceIndex, imageSurfaceInfo, wavelengthUm, precomputedContext: any = null, traceBackend: 'ts' | 'rust' = 'rust') {
+export function traceChiefRayForAngleDetails(opticalSystemRows, angleXDeg, angleYDeg, imageSurfaceIndex, imageSurfaceInfo, wavelengthUm, precomputedContext: any = null, traceBackend: 'ts' | 'rust' = 'rust') {
     if (traceBackend === 'rust') {
         const exact = traceImageHeightInfiniteChiefRayExactWithRust(
             opticalSystemRows,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "diag:grid-distortion-null-plot": "node --import tsx diagnostics/grid-distortion-null-plot-repro.mjs",
     "diag:grid-distortion-tele": "node --import tsx diagnostics/grid-distortion-tele-repro.mjs",
     "diag:spherical-aberration-continuity": "node --import tsx diagnostics/spherical-aberration-continuity-repro.mjs",
+    "diag:lateral-chromatic-wide": "node --import tsx diagnostics/lateral-chromatic-wide-repro.mjs",
     "wasm:rebuild": "bash ./scripts/build-rust-wasm.sh",
     "wasm:rebuild:threads": "bash -c 'COOPT_WASM_THREADS=1 bash ./scripts/build-rust-wasm.sh'",
     "state:inventory": "node tools/state-inventory.mjs",

--- a/src/ui/components/LegacyPanels.tsx
+++ b/src/ui/components/LegacyPanels.tsx
@@ -3241,7 +3241,7 @@ export default function LegacyPanels() {
               <input type="number" id="mca-xrange-input" defaultValue={0.04} min={0} step={0.01} />
               <span className="note">(mm)</span>
               <label htmlFor="mca-point-count-input" style={{ marginLeft: 10 }}>Points:</label>
-              <input type="number" id="mca-point-count-input" defaultValue={21} min={2} max={201} step={1} />
+              <input type="number" id="mca-point-count-input" defaultValue={41} min={2} max={201} step={1} />
               <label htmlFor="mca-ray-count-input" style={{ marginLeft: 10 }}>Rays:</label>
               <input type="number" id="mca-ray-count-input" defaultValue={101} min={1} max={5001} step={1} />
               <label htmlFor="mca-ring-count-input" style={{ marginLeft: 10 }}>Rings:</label>
@@ -3252,7 +3252,7 @@ export default function LegacyPanels() {
                 <option value="beam-centroid">Beam centroid</option>
               </select>
               <label htmlFor="mca-smoothing-adjacent-points-input" style={{ marginLeft: 10 }}>Smooth N:</label>
-              <input type="number" id="mca-smoothing-adjacent-points-input" defaultValue={1} min={0} max={50} step={1} />
+              <input type="number" id="mca-smoothing-adjacent-points-input" defaultValue={0} min={0} max={50} step={1} />
               <button id="show-magnification-chromatic-aberration-btn">Show lateral chromatic aberration</button>
             </div>
             <div id="mca-progress-wrapper" style={{ display: "none", margin: "8px 0" }}>

--- a/ui/event-handlers.ts
+++ b/ui/event-handlers.ts
@@ -9588,7 +9588,7 @@ export function setupAnalysisWindows() {
         <input type="number" id="popup-mca-xrange" value="0.04" min="0" step="0.01" />
         <span style="font-size:12px;color:#666;">(mm)</span>
         <label for="popup-mca-points" style="margin-left:6px;">Points:</label>
-        <input type="number" id="popup-mca-points" value="21" min="2" max="201" step="1" />
+        <input type="number" id="popup-mca-points" value="41" min="2" max="201" step="1" />
         <label for="popup-mca-rays" style="margin-left:6px;">Rays:</label>
         <input type="number" id="popup-mca-rays" value="101" min="1" max="5001" step="1" />
         <label for="popup-mca-rings" style="margin-left:6px;">Rings:</label>
@@ -9599,7 +9599,7 @@ export function setupAnalysisWindows() {
             <option value="beam-centroid">Beam centroid</option>
         </select>
         <label for="popup-mca-smooth-n" style="margin-left:6px;">Smooth N:</label>
-        <input type="number" id="popup-mca-smooth-n" value="1" min="0" max="50" step="1" />
+        <input type="number" id="popup-mca-smooth-n" value="0" min="0" max="50" step="1" />
         <button id="popup-show-mca-btn" type="button">Show lateral chromatic aberration</button>
     </div>
     <div id="popup-mca-progress-wrapper" style="display:none; padding: 8px 12px; font-size: 12px; color: #333; border-bottom: 1px solid #eee; background: #fff;">
@@ -9671,11 +9671,11 @@ export function setupAnalysisWindows() {
             const chiefRayEl = document.getElementById('popup-mca-chief-ray');
             const smoothNEl = document.getElementById('popup-mca-smooth-n');
             const xRange = xRangeEl ? parseFloat(xRangeEl.value) : 0.04;
-            const pointCount = pointEl ? parseInt(pointEl.value, 10) : 11;
+            const pointCount = pointEl ? parseInt(pointEl.value, 10) : 41;
             const rayCount = rayEl ? parseInt(rayEl.value, 10) : 101;
             const ringCount = ringEl ? parseInt(ringEl.value, 10) : 30;
             const chiefRayDefinition = (chiefRayEl && chiefRayEl.value) ? chiefRayEl.value : 'stop-center';
-            const smoothingAdjacentPoints = smoothNEl ? parseInt(smoothNEl.value, 10) : 1;
+            const smoothingAdjacentPoints = smoothNEl ? parseInt(smoothNEl.value, 10) : 0;
 
             try {
                 if (!window.opener || typeof window.opener.showMagnificationChromaticAberrationDiagram !== 'function') {


### PR DESCRIPTION
## What changed

- solve Image Height fields from the requested reference-wavelength chief-ray image height instead of using only `atan(height / EFL)`
- trace the fixed solved object field at every wavelength with the exact Rust/WASM stop-center chief-ray path
- increase the default LCA field sampling from 21 to 41 points
- disable plot smoothing by default and make optional smoothing include the current sample
- add a Wide Image Height LCA continuity regression

## Root cause

The LCA Image Height path used a paraxial angle approximation and then the generic angle-ray origin solver. In the Wide configuration, that solver changed to a fallback branch around 11 mm image height, creating a false straight segment and later kinks/reversals. The plotting smoother then obscured the underlying discontinuity.

## Validation

- `diag:lateral-chromatic-wide`: 41/41 finite samples; blue and red series monotonic through 21.6 mm; maximum adjacent changes 0.363 µm and 0.311 µm
- `diag:grid-distortion-field-modes`: passed
- `diag:spherical-aberration-continuity`: passed
- `npm run build`: passed
